### PR TITLE
[MAINT] Replace deprecated type `np.int`

### DIFF
--- a/ColorMapWriter.py
+++ b/ColorMapWriter.py
@@ -47,7 +47,7 @@ class ColorMapWriter(object):
         st_ind, end_ind = clr_range[0], clr_range[::-1][0]
 
         #num_ctrl_pts = len(range(0, num_tbl_pts, range_nudge))
-        num_ctrl_pts = np.arange(0,self.lookuptable.shape[0]+1, (self.lookuptable.shape[0]-1)/(self.ctrl_pt_number)).astype(np.int)
+        num_ctrl_pts = np.arange(0,self.lookuptable.shape[0]+1, (self.lookuptable.shape[0]-1)/(self.ctrl_pt_number)).astype(int)
         
         st_ind, end_ind = num_ctrl_pts[0], num_ctrl_pts[::-1][0]
 


### PR DESCRIPTION
As in #1, the `createLookupTable()` method uses the deprecated type `np.int` (since NumPy v1.20), which raises an `AttributeError` in newer versions of NumPy.

It is a simple fix of replacing `np.int` with `int` here, which i have changed in this PR:
https://github.com/gordon-n-stevenson/colormap_to_ITKSNAP/blob/d66208c1ce938deac3b4a51bdd88556a8dba8504/ColorMapWriter.py#L50

Cheers!